### PR TITLE
Fix DOI disappearing during fetchAffiliations hydration (SCIX-670)

### DIFF
--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -550,15 +550,9 @@ define([
         const ps = this.getPubSub();
         const query = this.getCurrentQuery().clone();
         query.unlock();
-        const {
-          bibcode,
-          author,
-          orcid_pub,
-          orcid_user,
-          orcid_other,
-        } = currentData;
+        const { bibcode, } = currentData;
         query.set('q', `identifier:${bibcode}`);
-        query.set('fl', ['author', 'aff', 'orcid_pub', 'orcid_user', 'orcid_other']);
+        query.set('fl', this.defaultQueryArguments.fl);
         query.set('rows', 1);
         ps.publish(
           ps.EXECUTE_REQUEST,
@@ -577,13 +571,7 @@ define([
                   resp.response.docs.length > 0
                 ) {
                   const freshDoc = resp.response.docs[0];
-                  const newEntries = this.model.parse({
-                    author: freshDoc.author || author,
-                    orcid_pub: freshDoc.orcid_pub || orcid_pub,
-                    orcid_user: freshDoc.orcid_user || orcid_user,
-                    orcid_other: freshDoc.orcid_other || orcid_other,
-                    aff: freshDoc.aff,
-                  });
+                  const newEntries = this.model.parse(freshDoc);
                   this._docs[bibcode] = {
                     ...this._docs[bibcode],
                     ...newEntries,


### PR DESCRIPTION
## Problem
The DOI was disappearing on abstract pages during hydration because the `fetchAffiliations` method was using a hardcoded field list (`fl`) that only included author/affiliation fields but excluded DOI fields.

## Solution
- Replace hardcoded field list with `this.defaultQueryArguments.fl` to ensure all necessary fields (including DOI) are preserved
- Simplify merge logic to use the full `freshDoc` instead of manually selecting specific fields
- Add comprehensive test case to verify DOI preservation during hydration

## Changes
- **Fixed**: DOI no longer disappears during abstract page hydration
- **Improved**: Better maintainability by using existing `defaultQueryArguments.fl`
- **Added**: Test case "should preserve DOI during fetchAffiliations hydration"

## Testing
- ✅ All existing tests pass (572 passing, 30 pending)
- ✅ New test specifically validates DOI preservation through hydration process

Fixes SCIX-670